### PR TITLE
Fix for buffer containing \0 characters

### DIFF
--- a/util/telnet-client.c
+++ b/util/telnet-client.c
@@ -100,7 +100,10 @@ static void _event_handler(telnet_t *telnet, telnet_event_t *ev,
 	switch (ev->type) {
 	/* data received */
 	case TELNET_EV_DATA:
-		printf("%.*s", (int)ev->data.size, ev->data.buffer);
+		int buf_size = (int)ev->data.size;
+        	if (buf_size && fwrite(ev->data.buffer, 1, buf_size, stdout) != buf_size) {
+            		fprintf(stderr, "ERROR: Could not write complete buffer to stdout");
+        	}
 		fflush(stdout);
 		break;
 	/* data must be sent */


### PR DESCRIPTION
As the server could return a large piece of data (e.g. a message-of-the-day) containing multiple \0 terminated strings, `printf("%.*s", ...)` is not sufficient for writing to `stdout` as that will stop on the first \0 character and not fully output the buffer to `stdout`.